### PR TITLE
Changing how cityhash is put in requirements.txt as it does not have package in pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@ gevent
 murmur
 urlnorm
 requests
-cityhash
+git+git://github.com/Amper/cityhash.git#egg=cityhash
 mysql-python
 python-magic
+nose
+mock
+ipython
+ipdb


### PR DESCRIPTION
Changing how cityhash is put in requirements.txt as it does not have package in pypi
